### PR TITLE
TOML.Merge: recursively merge nested tables

### DIFF
--- a/src/toml.adb
+++ b/src/toml.adb
@@ -667,7 +667,14 @@ package body TOML is
 
       for Key of R.Keys loop
          if Table.Has (Key) then
-            raise Constraint_Error with "duplicate key";
+            if Table.Get (Key).Kind /= TOML_Table
+              or else
+                R.Get (Key).Kind /= TOML_Table
+            then
+               raise Constraint_Error with "duplicate key";
+            else
+               Table.Set (Key, Merge (Table.Get (Key), R.Get (Key)));
+            end if;
          else
             Table.Set (Key, R.Get (Key));
          end if;

--- a/src/toml.ads
+++ b/src/toml.ads
@@ -341,9 +341,10 @@ package TOML with Preelaborate is
    function Merge (L, R : TOML_Value) return TOML_Value
       with Pre  => L.Kind = TOML_Table and then R.Kind = TOML_Table,
            Post => Merge'Result.Kind = TOML_Table;
-   --  Merge two tables. If a key is present in both, Constraint_Error is
-   --  raised. The operation is shallow, so the result table shares values with
-   --  L and R.
+   --  Merge two tables. If a key is present in both, Constraint_Error
+   --  is raised unless the key denotes nested tables that can be merged
+   --  recursively. The operation is shallow, so the result table shares
+   --  values with L and R.
 
    ---------------------
    -- Array modifiers --


### PR DESCRIPTION
The existing check on duplicate keys is too strict, as nested tables can be further merged recursively.