### PR TITLE
Add location information to TOML values, let the parser set it

### DIFF
--- a/tests/locations/example.toml
+++ b/tests/locations/example.toml
@@ -1,0 +1,24 @@
+[[bar.array]]
+a = true
+
+[foo]
+bool = false
+int = 12
+float = 0.98e12
+string = "bar"
+multiline_string = """
+  blip
+  blop
+"""
+local_date = 2134-01-19
+local_time = 12:34:56
+local_datetime = 2134-01-19 12:34:56
+offset_datetime = 2134-01-19 12:34:56+02:00
+
+inline_arrays = [
+   1, 2, [3,
+   4], 5
+]
+inline_table = { foo = 1, bar = {a = 2, b = 3} }
+dotted.keys.a = 1
+dotted.keys.b = 2

--- a/tests/locations/main.adb
+++ b/tests/locations/main.adb
@@ -1,0 +1,48 @@
+with Ada.Strings.Unbounded;
+with Ada.Text_IO;
+
+with TOML;
+with TOML.File_IO;
+
+procedure Main is
+   package TIO renames Ada.Text_IO;
+
+   procedure Process (Value : TOML.TOML_Value; Prefix : String);
+
+   -------------
+   -- Process --
+   -------------
+
+   procedure Process (Value : TOML.TOML_Value; Prefix : String) is
+      K : constant TOML.Any_Value_Kind := Value.Kind;
+   begin
+      TIO.Put (Prefix & "* " & K'Image);
+      if Value.Location.Line = 0 then
+         TIO.Put_Line (" [no location]");
+      else
+         TIO.Put_Line (" at " & TOML.Format_Location (Value.Location));
+      end if;
+      case K is
+         when TOML.TOML_Table =>
+            for E of Value.Iterate_On_Table loop
+               TIO.Put_Line
+                 (Prefix
+                  & "  " & Ada.Strings.Unbounded.To_String (E.Key) & ":");
+               Process (E.Value, Prefix & "    ");
+            end loop;
+
+         when TOML.TOML_Array =>
+            for I in 1 .. Value.Length loop
+               Process (Value.Item (I), Prefix & "    ");
+            end loop;
+
+         when others =>
+            null;
+      end case;
+   end Process;
+
+   Value : constant TOML.TOML_Value :=
+      TOML.File_IO.Load_File ("example.toml").Value;
+begin
+   Process (Value, "");
+end Main;

--- a/tests/locations/test.out
+++ b/tests/locations/test.out
@@ -1,0 +1,54 @@
+* TOML_TABLE [no location]
+  bar:
+    * TOML_TABLE at 1:1
+      array:
+        * TOML_ARRAY at 1:1
+            * TOML_TABLE at 1:1
+              a:
+                * TOML_BOOLEAN at 2:5
+  foo:
+    * TOML_TABLE at 4:1
+      bool:
+        * TOML_BOOLEAN at 5:8
+      dotted:
+        * TOML_TABLE at 23:1
+          keys:
+            * TOML_TABLE at 23:1
+              a:
+                * TOML_INTEGER at 23:17
+              b:
+                * TOML_INTEGER at 24:17
+      float:
+        * TOML_FLOAT at 7:9
+      inline_arrays:
+        * TOML_ARRAY at 18:17
+            * TOML_INTEGER at 19:4
+            * TOML_INTEGER at 19:7
+            * TOML_ARRAY at 19:10
+                * TOML_INTEGER at 19:12
+                * TOML_INTEGER at 20:4
+            * TOML_INTEGER at 20:8
+      inline_table:
+        * TOML_TABLE at 22:16
+          bar:
+            * TOML_TABLE at 22:33
+              a:
+                * TOML_INTEGER at 22:38
+              b:
+                * TOML_INTEGER at 22:45
+          foo:
+            * TOML_INTEGER at 22:24
+      int:
+        * TOML_INTEGER at 6:7
+      local_date:
+        * TOML_LOCAL_DATE at 13:14
+      local_datetime:
+        * TOML_LOCAL_DATETIME at 15:18
+      local_time:
+        * TOML_LOCAL_TIME at 14:14
+      multiline_string:
+        * TOML_STRING at 9:20
+      offset_datetime:
+        * TOML_OFFSET_DATETIME at 16:19
+      string:
+        * TOML_STRING at 8:10

--- a/tests/locations/test.yaml
+++ b/tests/locations/test.yaml
@@ -1,0 +1,1 @@
+driver: run-program


### PR DESCRIPTION
Add a `Location` primitive to `TOML_Value` and enhance all `TOML_Value` constructors so that they can specify a location to assign to created values. Also enhance the parser so that it assigns the right location to each TOML value it creates.

Closes https://github.com/pmderodat/ada-toml/issues/14